### PR TITLE
Fix ccache on windows workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
         with:
           max-size: '10G'
           key: ${{ matrix.config.os }}-${{ matrix.build_type }}
+          variant: ${{ matrix.config.os == 'windows-latest' && 'sccache' || 'ccache' }}
 
       - name: Configure
         run: >

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Dependencies (Windows)
         if: matrix.config.os == 'windows-latest'
         run: |
-          choco upgrade ccache ninja
+          choco upgrade ninja
 
       - name: Setup MSVC (Windows)
         if: matrix.config.os == 'windows-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,6 @@ jobs:
         with:
           max-size: '10G'
           key: ${{ matrix.config.os }}-${{ matrix.build_type }}
-          variant: ${{ matrix.config.os == 'windows-latest' && 'sccache' || 'ccache' }}
 
       - name: Configure
         run: >

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.22 )
+cmake_minimum_required( VERSION 3.25 )
 message( STATUS "Using CMake ${CMAKE_VERSION}" )
 
 set( FULL_PROJECT_NAME "GodotGeoRasters" )
@@ -22,10 +22,15 @@ set( CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON )
 set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 
 # Build universal lib on macOS
-# Note that CMAKE_OSX_ARCHITECTURES must be set before project().
+# Note: CMAKE_OSX_ARCHITECTURES must be set before project().
 if ( APPLE )
     set( CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" )
 endif()
+
+# ccache
+# Turns on ccache if found
+# Note: To work on MSVC the policy CMP0141 needs to be set to NEW before the first project call
+include( ccache )
 
 # Main project information
 project( ${FULL_PROJECT_NAME}
@@ -114,10 +119,6 @@ install( DIRECTORY "${CMAKE_SOURCE_DIR}/support_files/"
 )
 
 add_subdirectory( templates )
-
-# ccache
-# Turns on ccache if found
-include( ccache )
 
 # Formatting
 # Adds a custom target to format all the code at once

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required( VERSION 3.25 )
 message( STATUS "Using CMake ${CMAKE_VERSION}" )
 
+# Needed for ccache with MSVC
+# See: https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.html
+cmake_policy(SET CMP0141 NEW)
+
 set( FULL_PROJECT_NAME "GodotGeoRasters" )
 set( SHORT_PROJECT_NAME "GeoRasters" )
 set( PROJECT_GODOT_NAME "geo_rasters")
@@ -26,11 +30,6 @@ set( CMAKE_EXPORT_COMPILE_COMMANDS ON )
 if ( APPLE )
     set( CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" )
 endif()
-
-# ccache
-# Turns on ccache if found
-# Note: To work on MSVC the policy CMP0141 needs to be set to NEW before the first project call
-include( ccache )
 
 # Main project information
 project( ${FULL_PROJECT_NAME}
@@ -119,6 +118,10 @@ install( DIRECTORY "${CMAKE_SOURCE_DIR}/support_files/"
 )
 
 add_subdirectory( templates )
+
+# ccache
+# Turns on ccache if found
+include( ccache )
 
 # Formatting
 # Adds a custom target to format all the code at once

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -1,22 +1,39 @@
-# SPDX-License-Identifier: Unlicense
-
 # See: https://crascit.com/2016/04/09/using-ccache-with-cmake/
-find_program( CCACHE_PROGRAM ccache )
+find_program(CCACHE_PROGRAM ccache)
 
-if ( CCACHE_PROGRAM )
+if (CCACHE_PROGRAM)
     # get version information
     execute_process(
-        COMMAND "${CCACHE_PROGRAM}" --version
-        OUTPUT_VARIABLE CCACHE_VERSION
+            COMMAND "${CCACHE_PROGRAM}" --version
+            OUTPUT_VARIABLE CCACHE_VERSION
     )
+    string(REGEX MATCH "[^\r\n]*" CCACHE_VERSION ${CCACHE_VERSION})
 
-    string( REGEX MATCH "[^\r\n]*" CCACHE_VERSION ${CCACHE_VERSION} )
+    message(STATUS "Using ccache: ${CCACHE_PROGRAM} (${CCACHE_VERSION})")
 
-    message( STATUS "Using ccache: ${CCACHE_PROGRAM} (${CCACHE_VERSION})" )
+    # See: https://github.com/ccache/ccache/wiki/MS-Visual-Studio
+    if (MSVC)
+        message(STATUS "Configuring ccache for MSVC")
+        file(COPY_FILE
+                ${CCACHE_PROGRAM} ${CMAKE_BINARY_DIR}/cl.exe
+                ONLY_IF_DIFFERENT)
+
+        # By default Visual Studio generators will use /Zi which is not compatible
+        # with ccache, so tell Visual Studio to use /Z7 instead.
+        message(STATUS "Setting MSVC debug information format to 'Embedded'")
+        set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
+
+        set(CMAKE_VS_GLOBALS
+                "CLToolExe=cl.exe"
+                "CLToolPath=${CMAKE_BINARY_DIR}"
+                "UseMultiToolTask=true"
+                "DebugInformationFormat=OldStyle"
+        )
+    endif ()
 
     # Turn on ccache for all targets
-    set( CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" )
-    set( CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}" )
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
+    set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_PROGRAM}")
 
-    unset( CCACHE_VERSION )
-endif()
+    unset(CCACHE_VERSION)
+endif ()

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -1,6 +1,9 @@
 # See: https://crascit.com/2016/04/09/using-ccache-with-cmake/
 find_program(CCACHE_PROGRAM ccache)
 
+# See: https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.html
+cmake_policy(SET CMP0141 NEW)
+
 if (CCACHE_PROGRAM)
     # get version information
     execute_process(
@@ -20,6 +23,7 @@ if (CCACHE_PROGRAM)
 
         # By default Visual Studio generators will use /Zi which is not compatible
         # with ccache, so tell Visual Studio to use /Z7 instead.
+        # Note: This was added in Version 3.25 and policy CMP0141 must be set to NEW before the first project call
         message(STATUS "Setting MSVC debug information format to 'Embedded'")
         set(CMAKE_MSVC_DEBUG_INFORMATION_FORMAT "$<$<CONFIG:Debug,RelWithDebInfo>:Embedded>")
 

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -4,8 +4,8 @@ find_program(CCACHE_PROGRAM ccache)
 if (CCACHE_PROGRAM)
     # get version information
     execute_process(
-            COMMAND "${CCACHE_PROGRAM}" --version
-            OUTPUT_VARIABLE CCACHE_VERSION
+        COMMAND "${CCACHE_PROGRAM}" --version
+        OUTPUT_VARIABLE CCACHE_VERSION
     )
     string(REGEX MATCH "[^\r\n]*" CCACHE_VERSION ${CCACHE_VERSION})
 

--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -1,9 +1,6 @@
 # See: https://crascit.com/2016/04/09/using-ccache-with-cmake/
 find_program(CCACHE_PROGRAM ccache)
 
-# See: https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.html
-cmake_policy(SET CMP0141 NEW)
-
 if (CCACHE_PROGRAM)
     # get version information
     execute_process(


### PR DESCRIPTION
- Correctly sets up ccache on MSVC following [this guide](https://github.com/ccache/ccache/wiki/MS-Visual-Studio)
  - switches debug flag from `/Zi` to `/Z7` using `CMAKE_MSVC_DEBUG_INFORMATION_FORMAT`
  - renames ccache to cl.exe and points MSVC to it
- Bumps cmake minimum to 3.25 to support [CMAKE_MSVC_DEBUG_INFORMATION_FORMAT](https://cmake.org/cmake/help/latest/variable/CMAKE_MSVC_DEBUG_INFORMATION_FORMAT.html)
- Removes ccache from choco install for [performance](https://github.com/ccache/ccache/wiki/MS-Visual-Studio#installation)
  - ccache-action will install ccache directly if it is not preinstalled